### PR TITLE
feat: WooCommerce Plugin hides widget if Discount Rules active

### DIFF
--- a/woocommerce-upsy-tagging.php
+++ b/woocommerce-upsy-tagging.php
@@ -306,7 +306,7 @@ class WC_upsy_Tagging
 
 	}
 
-	public function check_wc_discount_related_plugins($target_plugin_name='Woo Discount Rules', $logged_in_user=true) {
+	public function check_wc_discount_related_plugins($target_plugin_name='Woo Discount Rules', $logged_in_user=false) {
 		if ( ! function_exists( 'get_plugins' ) ) {
        		 require_once ABSPATH . 'wp-admin/includes/plugin.php';
     	}


### PR DESCRIPTION
**Description:**

- Check WC discount rules plugin is found or not.
- If the WC discount rules plugin exists but is not active rules will not be applicable. 
- Check if the user logged in or not.
- If all the above conditions return true then we are hiding upsy widget otherwise not.