### PR TITLE
Bump up version number to 3.3.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,6 @@ Contributors:
 Tags: upsy tagging, woocommerce, e-commerce, ecommerce, personalization, recommendations
 Requires at least: 4.4.0
 Tested up to: 5.8.3
-Stable tag: 3.1.0
+Stable tag: 3.3.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-upsy-tagging.php
+++ b/woocommerce-upsy-tagging.php
@@ -4,7 +4,7 @@
 	Plugin URI: https://upsyshopping.com
 	Description: Enables UPSY for WooCommerce.
 	Author: Upsy Company Oy
-	Version: 3.1.0
+	Version: 3.3.0
 	License: GPL3
 */
 
@@ -22,7 +22,7 @@ class WC_upsy_Tagging
 	 *
 	 * @since 1.0.0
 	 */
-	const VERSION = '3.2.0';
+	const VERSION = '3.3.0';
 	
 	/**
 	 * Minimum WordPress version this plugin works with.


### PR DESCRIPTION
- woocommerce plugin will send purchase event so have to configure to stop sending purchase event from widget
- automatic plugin update notification and plugin update process
- etc